### PR TITLE
make strict_path_check rule specific, fix bug in option handling

### DIFF
--- a/testdata/badpathnostrictpath.json
+++ b/testdata/badpathnostrictpath.json
@@ -1,0 +1,27 @@
+{
+    "audit_rules": [
+        {
+            "key": "nonexist",
+            "path": "/non/existent/path",
+            "permission": "wa",
+            "strict_path_check": false
+        },
+        {
+            "actions": [
+                "always",
+                "exit"
+            ],
+            "fields": [
+                {
+                    "name": "arch",
+                    "op": "eq",
+                    "value": 64
+                }
+            ],
+            "key": "bypass",
+            "syscalls": [
+                "personality"
+            ]
+        }
+    ]
+}

--- a/testdata/strictpathfail.json
+++ b/testdata/strictpathfail.json
@@ -1,0 +1,10 @@
+{
+    "audit_rules": [
+        {
+            "key": "nonexist",
+            "path": "/non/existent/path",
+            "permission": "wa",
+            "strict_path_check": true
+        }
+    ]
+}


### PR DESCRIPTION
Makes strict_path_check specific to an individual audit rule, instead of
a global option for the rule set.

This also fixes the way the option was being handled, previously if
strict_path_check was enabled and the watch rule could not find the
file, it would continue instead of returning resulting in a panic.

Closes #18