### PR TITLE
Improve netlink support, handle partial record reassembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ To get started see package documentation at [godoc](https://godoc.org/github.com
 
 For a simple example of usage, see the [auditprint](./auditprint/) tool included in this repository.
 
+```bash
+sudo service stop auditd
+go get -u github.com/mozilla/libaudit-go
+cd $GOPATH/src/github.com/mozilla/libaudit-go
+go install github.com/mozilla/libaudit-go/auditprint
+sudo $GOPATH/bin/auditprint testdata/rules.json
+```
+
 Some key functions are discussed in the overview section below.
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ libaudit-go can be used to build go applications which perform tasks similar to 
 
 To get started see package documentation at [godoc](https://godoc.org/github.com/mozilla/libaudit-go).
 
+For a simple example of usage, see the [auditprint](./auditprint/) tool included in this repository.
+
 Some key functions are discussed in the overview section below.
 
 ## Overview

--- a/auditprint/auditprint.go
+++ b/auditprint/auditprint.go
@@ -18,7 +18,13 @@ import (
 
 func auditProc(e *libaudit.AuditEvent, err error) {
 	if err != nil {
-		fmt.Printf("callback received error: %v\n", err)
+		// See if the error is libaudit.ErrorAuditParse, if so convert and also display
+		// the audit record we could not parse
+		if nerr, ok := err.(libaudit.ErrorAuditParse); ok {
+			fmt.Printf("parser error: %v: %v\n", nerr, nerr.Raw)
+		} else {
+			fmt.Printf("callback received error: %v\n", err)
+		}
 		return
 	}
 	// Marshal the event to JSON and print

--- a/auditprint/auditprint.go
+++ b/auditprint/auditprint.go
@@ -1,0 +1,99 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// auditprint is a simple command line tool that loads an audit rule set from a JSON file,
+// applies it to the current kernel and begins printing any audit event the kernel sends in
+// JSON format.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/mozilla/libaudit-go"
+)
+
+func auditProc(e *libaudit.AuditEvent, err error) {
+	if err != nil {
+		fmt.Printf("callback received error: %v\n", err)
+		return
+	}
+	// Marshal the event to JSON and print
+	buf, err := json.Marshal(e)
+	if err != nil {
+		fmt.Printf("callback was unable to marshal event: %v\n", err)
+		return
+	}
+	fmt.Printf("%v\n", string(buf))
+}
+
+func main() {
+	s, err := libaudit.NewNetlinkConnection()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "NetNetlinkConnection: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(os.Args) != 2 {
+		fmt.Printf("usage: %v path_to_rules.json\n", os.Args[0])
+		os.Exit(0)
+	}
+
+	err = libaudit.AuditSetEnabled(s, true)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "AuditSetEnabled: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = libaudit.AuditSetPID(s, os.Getpid())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "AuditSetPid: %v\n", err)
+		os.Exit(1)
+	}
+	err = libaudit.AuditSetRateLimit(s, 1000)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "AuditSetRateLimit: %v\n", err)
+		os.Exit(1)
+	}
+	err = libaudit.AuditSetBacklogLimit(s, 250)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "AuditSetBacklogLimit: %v\n", err)
+		os.Exit(1)
+	}
+
+	var ar libaudit.AuditRules
+	buf, err := ioutil.ReadFile(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ReadFile: %v\n", err)
+		os.Exit(1)
+	}
+	// Make sure we can unmarshal the rules JSON to validate it is the correct
+	// format
+	err = json.Unmarshal(buf, &ar)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unmarshaling rules JSON: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Remove current rule set and send rules to the kernel
+	err = libaudit.DeleteAllRules(s)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "DeleteAllRules: %v\n", err)
+		os.Exit(1)
+	}
+	warnings, err := libaudit.SetRules(s, buf)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "SetRules: %v\n", err)
+		os.Exit(1)
+	}
+	// Print any warnings we got back but still continue
+	for _, x := range warnings {
+		fmt.Fprintf(os.Stderr, "ruleset warning: %v\n", x)
+	}
+
+	doneCh := make(chan bool, 1)
+	libaudit.GetAuditMessages(s, auditProc, &doneCh)
+}

--- a/buffer.go
+++ b/buffer.go
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package libaudit
+
+import (
+	"strconv"
+)
+
+var bufferMap map[uint64][]*AuditEvent
+
+// bufferEvent buffers an incoming audit event which contains partial record informatioa.
+func bufferEvent(a *AuditEvent) {
+	if bufferMap == nil {
+		bufferMap = make(map[uint64][]*AuditEvent)
+	}
+
+	serial, err := strconv.ParseUint(a.Serial, 10, 64)
+	if err != nil {
+		return
+	}
+	if _, ok := bufferMap[serial]; !ok {
+		bufferMap[serial] = make([]*AuditEvent, 5)
+	}
+	bufferMap[serial] = append(bufferMap[serial], a)
+}
+
+// bufferGet returns the complete audit event from the buffer, given the AUDIT_EOE event a.
+func bufferGet(a *AuditEvent) *AuditEvent {
+	serial, err := strconv.ParseUint(a.Serial, 10, 64)
+	if err != nil {
+		return nil
+	}
+
+	var (
+		bm []*AuditEvent
+		ok bool
+	)
+	if bm, ok = bufferMap[serial]; !ok {
+		return nil
+	}
+	rlen := len(a.Raw)
+	for i := range bm {
+		if bm[i] == nil {
+			continue
+		}
+		for k, v := range bm[i].Data {
+			a.Data[k] = v
+		}
+		if len(bm[i].Raw) > rlen {
+			a.Raw += " " + bm[i].Raw[rlen:]
+		}
+	}
+
+	delete(bufferMap, serial)
+	return a
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -280,17 +280,18 @@ func TestMalformedPrefix(t *testing.T) {
 	tmsg := []struct {
 		msg     string
 		msgType auditConstant
+		err     string
 	}{
-		{"xyzabc", AUDIT_AVC},
-		{`audit(1464163771`, AUDIT_AVC},
-		{`audit(1464176620.068:1445`, AUDIT_AVC},
+		{"xyzabc", AUDIT_AVC, "malformed, missing audit prefix"},
+		{`audit(1464163771`, AUDIT_AVC, "malformed, can't locate start of fields"},
+		{`audit(1464176620.068:1445`, AUDIT_AVC, "malformed, can't locate end of prefix"},
 	}
 	for _, m := range tmsg {
 		_, err := ParseAuditEvent(m.msg, m.msgType, false)
 		if err == nil {
 			t.Fatalf("ParseAuditEvent should have failed on %q", m.msg)
 		}
-		if err.Error() != "malformed audit message" {
+		if err.Error() != m.err {
 			t.Fatalf("ParseAuditEvent failed, but error %q was unexpected", err)
 		}
 	}


### PR DESCRIPTION
* Improves handling of certain netlink messages which were being truncated
* On parser failure, return a custom error type that include the raw event for inspection
* Buffer and reassemble partial records; this handles AUDIT_EOE and returns the full audit event when it is comprised of multiple individual netlink messages