### PR TITLE
Error comparing PID values in auditGetReply()

### DIFF
--- a/libaudit.go
+++ b/libaudit.go
@@ -315,12 +315,12 @@ done:
 			if err != nil {
 				return ret, err
 			}
-			if m.Header.Seq != seq {
-				// Wasn't the sequence number we are looking for, just discard it
+			if socketPID != os.Getpid() {
+				// PID didn't match, just discard it
 				continue
 			}
-			if int(m.Header.Pid) != socketPID {
-				// PID didn't match, just discard it
+			if m.Header.Seq != seq {
+				// Wasn't the sequence number we are looking for, just discard it
 				continue
 			}
 			if m.Header.Type == syscall.NLMSG_DONE {


### PR DESCRIPTION
struct sockaddr_nl {
	__kernel_sa_family_t	        nl_family;	        /* AF_NETLINK */
	unsigned short			nl_pad;		/* zero */
	__u32					nl_pid;		/* port ID */
         __u32					nl_groups;	/* multicast groups mask */
};
"sockaddr_nl->nl_pid" is s.GetPID().

and m.Header.Pid is "nlmsghdr->nlmsg_pid":
struct nlmsghdr {
	__u32		nlmsg_len;	/* Length of message including header */
	__u16		nlmsg_type;	/* Message content */
	__u16		nlmsg_flags;	/* Additional flags */
	__u32		nlmsg_seq;	/* Sequence number */
	__u32		nlmsg_pid;	/* Sending process port ID */
};

nlmsg_pid; /* Sending process port ID */  the replay packet from kernel mlmsg_pid could be 0.

This situation resulted in libaudit-go not working and unable to receive kernel information when the kernel version was "4.13.0-37-generic #42~16.04.1-Ubuntu SMP x86_64".

In auditd source code, “nlmsg_pid” never participated in the comparison.