### PR TITLE
Fix rules checkPath error printing

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -641,7 +641,7 @@ func checkPath(pathName string) error {
 		return fmt.Errorf("path %q too large", pathName)
 	}
 	if pathName[0] != '/' {
-		return fmt.Errorf("path %q must be absolute")
+		return fmt.Errorf("path %q must be absolute", pathName)
 	}
 	if strings.Contains(pathName, "..") {
 		return fmt.Errorf("path %q cannot contain special directory values", pathName)


### PR DESCRIPTION
It was a small mistake, because of which the tests did not pass.